### PR TITLE
WIP: include init action in log

### DIFF
--- a/src/monitors/log-monitor/log-monitor.ts
+++ b/src/monitors/log-monitor/log-monitor.ts
@@ -25,6 +25,10 @@ import {LogMonitorButton} from './log-monitor-button';
       direction: ltr;
     }
 
+     :host:first-child .title-bar {
+       opacity: .6; cursor: auto;
+     }
+
     .button-bar{
       text-align: center;
       border-bottom-width: 1px;
@@ -48,11 +52,11 @@ import {LogMonitorButton} from './log-monitor-button';
   `],
   template: `
     <div class="button-bar">
-      <log-monitor-button (action)="handleReset()" [disabled]="canReset$ | async">
+      <log-monitor-button (action)="handleReset()" [disabled]="canRevert$ | async">
         Reset
       </log-monitor-button>
 
-      <log-monitor-button (action)="handleRollback()">
+      <log-monitor-button (action)="handleRollback() [disabled]="canRevert$ | async"">
         Revert
       </log-monitor-button>
 
@@ -108,12 +112,14 @@ export class LogMonitor{
           });
         }
 
-        return actions.slice(1);
+        return actions;
       });
   }
 
   handleToggle(id: number){
-    this.devtools.toggleAction(id);
+    if (id > 0) {
+      this.devtools.toggleAction(id);
+    }
   }
 
   handleReset(){


### PR DESCRIPTION
* don't slice away init from items$
* use canRevert$ to disable both the Reset and Revert buttons
* prevent reverting or resetting the init action
* style the init (first) action to reflect that it cannot by undone

All that works now as I'd expect, though I don't know if its 100% what the redux version does.

TODO: tests

@MikeRyan52 @robwormald -- I'd like to add tests for LogMonitor. Do you have a preferred strategy for a loader that would get the code into Karma? Left to my own devices, I'd be using jspm *(EDIT: or at least systemjs)* because that's what I know, but I think neither of you want to see that.  @robwormald I know you're interested in stealjs. Is now the time to figure that out? @MikeRyan52 what would you do? Should we test the `dist` directory and thus avoid transpile issues within the tests?