### PR TITLE
chore(deps): update angular, rxjs, store

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,25 +40,25 @@
   },
   "homepage": "https://github.com/ngrx/devtools#readme",
   "devDependencies": {
-    "rxjs": "^5.0.0-beta.2",
-    "angular2": "^2.0.0-beta.7",
-    "@ngrx/store": "^1.3.2",
+    "rxjs": "^5.0.0-beta.6",
+    "angular2": "^2.0.0-beta.17",
+    "@ngrx/store": "^1.4.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.13",
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
     "lodash": "^3.10.1",
-    "reflect-metadata": "0.1.2",
+    "reflect-metadata": "^0.1.2",
     "rimraf": "^2.5.1",
     "tslint": "^3.4.0",
     "typescript": "^1.8.7",
     "typings": "^0.6.6",
-    "zone.js": "0.5.15"
+    "zone.js": "^0.5.15"
   },
   "peerDependencies": {
-    "rxjs": "^5.0.0-beta.2",
-    "angular2": "^2.0.0-beta.7",
-    "@ngrx/store": "^1.3.2"
+    "rxjs": "^5.0.0-beta.6",
+    "angular2": "^2.0.0-beta.17",
+    "@ngrx/store": "^1.4.0"
   },
   "typings": "./dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
   },
   "homepage": "https://github.com/ngrx/devtools#readme",
   "devDependencies": {
-    "rxjs": "^5.0.0-beta.6",
-    "angular2": "^2.0.0-beta.17",
-    "@ngrx/store": "^1.4.0",
+    "@angular/core": "^2.0.0-rc.0",
+    "@ngrx/store": "^1.5.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.13",
     "jasmine": "^2.4.1",
@@ -50,15 +49,16 @@
     "lodash": "^3.10.1",
     "reflect-metadata": "^0.1.2",
     "rimraf": "^2.5.1",
+    "rxjs": "^5.0.0-beta.6",
     "tslint": "^3.4.0",
     "typescript": "^1.8.7",
     "typings": "^0.6.6",
-    "zone.js": "^0.5.15"
+    "zone.js": "^0.6.12"
   },
   "peerDependencies": {
+    "@angular/core": "^2.0.0-rc.0",
     "rxjs": "^5.0.0-beta.6",
-    "angular2": "^2.0.0-beta.17",
-    "@ngrx/store": "^1.4.0"
+    "@ngrx/store": "^1.5.0"
   },
   "typings": "./dist/index.d.ts"
 }

--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -2,7 +2,7 @@ declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptio
 require('es6-shim');
 require('reflect-metadata');
 import {Observable} from 'rxjs/Observable';
-import {ReflectiveInjector, provide} from 'angular2/core';
+import {ReflectiveInjector, provide} from '@angular/core';
 import {Dispatcher, provideStore, Store, StoreBackend} from '@ngrx/store';
 
 import { StoreDevtools, instrumentStore } from '../src';

--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -2,7 +2,7 @@ declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptio
 require('es6-shim');
 require('reflect-metadata');
 import {Observable} from 'rxjs/Observable';
-import {Injector, provide} from 'angular2/core';
+import {ReflectiveInjector, provide} from 'angular2/core';
 import {Dispatcher, provideStore, Store, StoreBackend} from '@ngrx/store';
 
 import { StoreDevtools, instrumentStore } from '../src';
@@ -38,7 +38,7 @@ describe('instrument', () => {
   let devtools: StoreDevtools;
 
   function createStore(reducer, monitorReducer = T => T){
-    const injector = Injector.resolveAndCreate([
+    const injector = ReflectiveInjector.resolveAndCreate([
       provideStore(reducer),
       instrumentStore(monitorReducer)
     ]);
@@ -56,7 +56,7 @@ describe('instrument', () => {
   });
 
   it('should alias devtools to the store backend', () => {
-    const injector = Injector.resolveAndCreate([
+    const injector = ReflectiveInjector.resolveAndCreate([
       provideStore(counter),
       instrumentStore()
     ]);

--- a/src/monitors/devtools.ts
+++ b/src/monitors/devtools.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from 'angular2/core';
+import {Component, Input} from '@angular/core';
 import {LogMonitor} from './log-monitor/log-monitor';
 import {DockMonitor} from './dock-monitor/dock-monitor';
 

--- a/src/monitors/dock-monitor/actions.ts
+++ b/src/monitors/dock-monitor/actions.ts
@@ -1,4 +1,4 @@
-import {Injectable} from 'angular2/core';
+import {Injectable} from '@angular/core';
 import {Action} from '@ngrx/store';
 
 

--- a/src/monitors/dock-monitor/commander.ts
+++ b/src/monitors/dock-monitor/commander.ts
@@ -1,6 +1,6 @@
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/map';
-import {Component, Input, Output, Injectable, Renderer} from 'angular2/core';
+import {Component, Input, Output, Injectable, Renderer} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {Subscriber} from 'rxjs/Subscriber';

--- a/src/monitors/dock-monitor/dock-monitor.ts
+++ b/src/monitors/dock-monitor/dock-monitor.ts
@@ -3,7 +3,7 @@ import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/distinctUntilChanged';
 import {StoreDevtools} from '../../store/devtools';
-import {Component, ChangeDetectionStrategy, Input} from 'angular2/core';
+import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import {Subject} from 'rxjs/Subject';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';

--- a/src/monitors/dock-monitor/dock.ts
+++ b/src/monitors/dock-monitor/dock.ts
@@ -1,4 +1,4 @@
-import {Component, HostListener, HostBinding, Input} from 'angular2/core';
+import {Component, HostListener, HostBinding, Input} from '@angular/core';
 import {PositionsType} from './reducer';
 
 

--- a/src/monitors/log-monitor/log-monitor-button.ts
+++ b/src/monitors/log-monitor/log-monitor-button.ts
@@ -7,7 +7,7 @@ import {
   EventEmitter,
   HostListener,
   HostBinding
-} from 'angular2/core';
+} from '@angular/core';
 
 @Component({
   selector: 'log-monitor-button',

--- a/src/monitors/log-monitor/log-monitor-entry.ts
+++ b/src/monitors/log-monitor/log-monitor-entry.ts
@@ -6,7 +6,7 @@ import {
   Output,
   EventEmitter,
   HostListener
-} from 'angular2/core';
+} from '@angular/core';
 
 import {LogEntryItem} from './log-entry-item';
 import {LogMonitorButton} from './log-monitor-button';

--- a/src/monitors/log-monitor/log-monitor.ts
+++ b/src/monitors/log-monitor/log-monitor.ts
@@ -1,4 +1,4 @@
-import {Inject, Component, ViewEncapsulation, ChangeDetectionStrategy} from 'angular2/core';
+import {Inject, Component, ViewEncapsulation, ChangeDetectionStrategy} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 

--- a/src/monitors/log-monitor/log-monitor.ts
+++ b/src/monitors/log-monitor/log-monitor.ts
@@ -66,7 +66,7 @@ import {LogMonitorButton} from './log-monitor-button';
     </div>
     <div class="elements">
       <log-monitor-entry
-        *ngFor="#item of (items$ | async)"
+        *ngFor="let item of (items$ | async)"
         [item]="item"
         (toggle)="handleToggle($event.id)">
       </log-monitor-entry>

--- a/src/store/devtools.ts
+++ b/src/store/devtools.ts
@@ -1,5 +1,5 @@
 import {Subject} from 'rxjs/Subject';
-import {BehaviorSubject} from 'rxjs/subject/BehaviorSubject';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Observer} from 'rxjs/Observer';
 import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/scan';
@@ -8,7 +8,7 @@ import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
 
 import {Dispatcher, Middleware, Reducer} from '@ngrx/store';
-import {ActionTypes} from '@ngrx/store/dist/store-backend';
+import {ActionTypes} from '@ngrx/store/store-backend';
 import {liftReducerWith, LiftedState} from './reducer';
 import {StoreDevtoolActions as actions} from './actions';
 import {liftAction, unliftState} from './utils';

--- a/src/store/instrument.ts
+++ b/src/store/instrument.ts
@@ -1,4 +1,4 @@
-import {provide, Provider, OpaqueToken} from 'angular2/core';
+import {provide, Provider, OpaqueToken} from '@angular/core';
 import * as store from '@ngrx/store';
 
 import {StoreDevtools} from './devtools';


### PR DESCRIPTION
(I realize this might not be needed, but if anyone needs a version compatible with angular rc.0/rxjs beta.6, I think this ought to work.)

* angular updated to ~~^2.0.0-beta.17~~ ^2.0.0-rc.0
* rxjs updated to ^5.0.0-beta.6
* @ngrx/store updated to ~~^1.4.0~~ ^1.5.0
* reflect-metadata allowed to float from ^0.1.2 upward
* zone.js allowed to float from ~~^0.5.15~~ ^0.6.12 upward

(The last two changes for reasons that the versions/ranges that angular
requires should be the versions used here.)

* update LogMonitor template `for` syntax